### PR TITLE
http: Upgrade components signatues to use std::experimental::string_view

### DIFF
--- a/inc/header.hpp
+++ b/inc/header.hpp
@@ -18,11 +18,9 @@
 #ifndef HTTP_HEADER_HPP
 #define HTTP_HEADER_HPP
 
-#include <cctype>
-#include <utility>
-#include <ostream>
-#include <sstream>
 #include <algorithm>
+#include <cctype>
+#include <sstream>
 #include <type_traits>
 
 #include "common.hpp"
@@ -39,16 +37,12 @@ namespace http {
  * and provided method
  */
 class Header {
-private:
-  //-----------------------------------------------
-  // Internal class type aliases
-  using Const_iterator = Header_set::const_iterator;
-  //-----------------------------------------------
 public:
   /**
    * @brief Default constructor that limits the amount
    * of fields that can be added to 25
    */
+  template<typename = void>
   explicit Header() noexcept;
 
   /**
@@ -58,28 +52,21 @@ public:
    * @param limit:
    * Capacity of how many fields that can be added
    */
+  template<typename = void>
   explicit Header(const Limit limit) noexcept;
 
   /**
    * @brief Constructor that takes a stream of characters
-   * as a {std::string} object and parses it into a set
-   * of name-value pairs
+   * and parses it into a set of name-value pairs
    *
-   * @tparam T header_data:
+   * @param header_data:
    * The character stream of data to parse
    *
    * @param limit:
    * Capacity of how many fields can be added
    */
-  template
-  <
-    typename T,
-    typename = std::enable_if_t
-               <std::is_same
-               <std::string, std::remove_const_t
-               <std::remove_reference_t<T>>>::value>
-  >
-  explicit Header(T&& header_data, const Limit limit = 25);
+  template<typename = void>
+  explicit Header(const std::experimental::string_view header_data, const Limit limit = 25);
 
   /**
    * Default destructor
@@ -104,172 +91,115 @@ public:
   /**
    * Default move assignemt operator
    */
-  Header& operator = (Header&&) = default;
-
-  /**
-   * @brief Set the limit of how many fields can be added
-   *
-   * @param limit:
-   * Capacity of how many fields can be added
-   */
-  void set_limit(const Limit limit) noexcept;
+  Header& operator = (Header&&) noexcept = default;
 
   /**
    * @brief Get the current capacity
    *
    * @return The current capacity of the set
    */
-  Limit get_limit() const noexcept;
+  template<typename = void>
+  Limit limit() const noexcept;
 
   /**
    * @brief Add a new field to the current set
    *
-   * @tparam F field:
+   * @param field:
    * The name of the field
    *
-   * @tparam V value:
+   * @param value:
    * The field value
    *
    * @return true if the field was added, false otherwise
    */
-  template
-  <
-    typename F, typename V,
-    typename = std::enable_if_t
-               <std::is_same
-               <std::string, std::remove_const_t
-               <std::remove_reference_t<F>>>::value and
-                std::is_same
-               <std::string, std::remove_const_t
-               <std::remove_reference_t<V>>>::value>
-  >
-  bool add_field(F&& field, V&& value);
+  template<typename = void>
+  bool add_field(const std::experimental::string_view field, const std::experimental::string_view value);
 
   /**
    * @brief Add a set of fields to the current set from
-   * a {std::string} object in the following format:
+   * a stream of characters in the following format:
    *
    * "name: value\r\n"
    * "name: value\r\n"
    * ...
    *
-   * @tparam D data - The set of fields to add
+   * @param data
+   * The set of fields to add
    */
-  template
-  <
-    typename D,
-    typename = std::enable_if_t
-               <std::is_same
-               <std::string, std::remove_const_t
-               <std::remove_reference_t<D>>>::value>
-  >
-  void add_fields(D&& data);
+  void add_fields(const std::experimental::string_view data);
 
   /**
    * @brief Change the value of the specified field
    *
-   * If the field is absent from the set it will
-   * be added with the associated value once its
-   * within capacity
+   * If the field is absent it will be added with
+   * the associated value once its within capacity
    *
-   * @tparam F field:
+   * @param field:
    * The name of the field
 
-   * @tparam V value:
+   * @param value:
    * The field value
    *
    * @return true if successful, false otherwise
    */
-  template
-  <
-    typename F, typename V,
-    typename = std::enable_if_t
-               <std::is_same
-               <std::string, std::remove_const_t
-               <std::remove_reference_t<F>>>::value and
-                std::is_same
-               <std::string, std::remove_const_t
-               <std::remove_reference_t<V>>>::value>
-  >
-  bool set_field(F&& field, V&& value);
+  template<typename = void>
+  bool set_field(const std::experimental::string_view field, const std::experimental::string_view value);
 
   /**
    * @brief Get the value associated with a field
    *
-   * Should call <has_field> before calling this
-   *
-   * @tparam F field:
+   * @param field:
    * The name of the field
    *
    * @return The value associated with the specified
-   * field name
+   * field name if exist, empty view otherwise
    */
-  template
-  <
-    typename F,
-    typename = std::enable_if_t
-               <std::is_same
-               <std::string, std::remove_const_t
-               <std::remove_reference_t<F>>>::value>
-  >
-  const std::string& get_value(F&& field) const noexcept;
+  template<typename = void>
+  std::experimental::string_view value(const std::experimental::string_view field) const noexcept;
 
   /**
-   * @brief Check to see if the specified field is a
-   * member of the set of fields
+   * @brief Check to see if the specified field is present
    *
-   * @tparam F field:
+   * @param field:
    * The name of the field
    *
    * @return true if the field is a member, false otherwise
    */
-  template
-  <
-    typename F,
-    typename = std::enable_if_t
-               <std::is_same
-               <std::string, std::remove_const_t
-               <std::remove_reference_t<F>>>::value>
-  >
-  bool has_field(F&& field) const noexcept;
+  template<typename = void>
+  bool has_field(const std::experimental::string_view field) const noexcept;
 
   /**
-   * @brief Check to see if the set of fields is empty
+   * @brief Check to see if there are no fields present
    *
-   * @return true if there are no fields within the set,
+   * @return true if there are no fields present,
    * false otherwise
    */
+  template<typename = void>
   bool is_empty() const noexcept;
 
   /**
    * @brief Check to see how many fields are currently
-   * in the set of fields
+   * present
    *
-   * @return The amount of fields currently in the set
+   * @return The amount of fields currently present
    */
+  template<typename = void>
   Limit size() const noexcept;
 
   /**
-   * @brief Remove all fields from the set of fields with the
+   * @brief Remove all fields currently present with the
    * specified name
    *
-   * @tparam F field:
+   * @param field:
    * The name of the field to remove
    */
-  template
-  <
-    typename F,
-    typename = std::enable_if_t
-               <std::is_same
-               <std::string, std::remove_const_t
-               <std::remove_reference_t<F>>>::value>
-  >
-  void erase(F&& field) noexcept;
+  template<typename = void>
+  void erase(const std::experimental::string_view field) noexcept;
 
   /**
-   * @brief Remove all fields from the set of fields leaving
-   * it empty
+   * @brief Remove all fields leaving none present
    */
+  template<typename = void>
   void clear() noexcept;
 
   /**
@@ -278,7 +208,7 @@ public:
    *
    * @return A string representation
    */
-  virtual std::string to_string() const;
+  std::string to_string() const;
 
   /**
    * @brief Operator to transform this class
@@ -292,252 +222,208 @@ private:
   //-----------------------------------------------
 
   /**
+   * @brief Set the limit of how many fields can be added
+   *
+   * @param limit:
+   * Capacity of how many fields can be added
+   */
+  template<typename = void>
+  void set_limit(const Limit limit) noexcept;
+
+  /**
    * @brief Find the location of a field within the set of
    * fields
    *
-   * @tparam F field:
-   * The field name to locate a field within the set of fields
+   * @param field:
+   * The field name to locate a field if present
    *
    * @return Iterator to the location of the field, else
    * location to the end of the sequence
    */
-  template
-  <
-    typename F,
-    typename = std::enable_if_t
-               <std::is_same
-               <std::string, std::remove_const_t
-               <std::remove_reference_t<F>>>::value>
-  >
-  Const_iterator find(F&& field) const noexcept;
-
-  /**
-   * @brief Operator to stream the contents of the set of fields
-   * into the specified output device
-   *
-   * The output format is as follows:
-   * field : value "\r\n"
-   * field : value "\r\n"
-   * ...
-   * "\r\n"
-   *
-   * @param output_device:
-   * The output device to stream the contents from an instance of this
-   * class into
-   *
-   * @param header:
-   * An instance of this class
-   *
-   * @return Reference to the specified output device
-   */
-  friend std::ostream& operator << (std::ostream& output_device, const Header& header);
-}; //< class Header
+  template<typename = void>
+  Header_set::const_iterator find(const std::experimental::string_view field) const noexcept;
+};
 
 /**--v----------- Implementation Details -----------v--**/
 
+template<typename>
 inline Header::Header() noexcept {
-  set_limit(25);
+  set_limit(25U);
 }
 
+template<typename>
 inline Header::Header(const Limit limit) noexcept {
   set_limit(limit);
 }
 
-template <typename T, typename>
-inline Header::Header(T&& header_data, const Limit limit)
+template<typename>
+inline Header::Header(const std::experimental::string_view header_data, const Limit limit)
   : Header {limit}
 {
   add_fields(header_data);
 }
 
-inline void Header::set_limit(const Limit limit) noexcept {
-  fields_.reserve(limit);
-}
-
-inline Limit Header::get_limit() const noexcept {
+template<typename>
+inline Limit Header::limit() const noexcept {
   return fields_.capacity();
 }
 
-template <typename Field, typename Value, typename>
-inline bool Header::add_field(Field&& field, Value&& value) {
-  if (field.empty()) return false;
-  //-----------------------------------
-  if (size() < fields_.capacity()) {
-    fields_.emplace_back(std::forward<Field>(field), std::forward<Value>(value));
+template<typename>
+inline bool Header::add_field(const std::experimental::string_view field, const std::experimental::string_view value) {
+  if ((not field.empty()) and (size() < limit())) {
+    fields_.emplace_back(field, value);
     return true;
   }
-  //-----------------------------------
+
   return false;
 }
 
-template <typename Data, typename>
-inline void Header::add_fields(Data&& data) {
-  if (data.empty()) return;
+inline void Header::add_fields(std::experimental::string_view fields_view) {
+  if (fields_view.empty() or (size() == limit())) return;
   //-----------------------------------
-  auto iterator = data.cbegin();
-  auto sentinel = data.cend();
+  std::experimental::string_view field {};
+  std::experimental::string_view value {};
+  std::experimental::string_view::size_type base {0U};
+  std::experimental::string_view::size_type break_point {};
   //-----------------------------------
-  std::string field;
-  std::string value;
-  field.reserve(24);
-  value.reserve(64);
+  fields_view.remove_prefix(fields_view.find_first_not_of(' '));
   //-----------------------------------
-  Limit limit {0};
-  int character = *iterator;
-  const int stop_char = std::char_traits<std::string::value_type>::eof();
-  //-----------------------------------
-  while (iterator not_eq sentinel
-         and character not_eq stop_char
-         and limit < fields_.capacity())
-  {
-    field.clear();
-    value.clear();
-    //-----------------------------------
-    while (iterator not_eq sentinel and isspace(character)) {
-      character = *++iterator;
-    }
-    //-----------------------------------
-    while (iterator not_eq sentinel
-           and character not_eq stop_char
-           and character not_eq ':'
-           and not iscntrl(character)
-           and not isspace(character))
-    {
-      field += character;
-      character = *++iterator;
-    }
-    //-----------------------------------
-    while (iterator not_eq sentinel and isspace(character)) {
-      character = *++iterator;
-    }
-    //-----------------------------------
-    if (character not_eq ':') return;
-    //-----------------------------------
-    if (iterator not_eq sentinel) character = *++iterator;
-    //-----------------------------------
-    while (iterator not_eq sentinel and isspace(character)) {
-      character = *++iterator;
-    }
-    //-----------------------------------
-parse_value:
-    while (iterator not_eq sentinel
-           and character not_eq stop_char
-           and not iscntrl(character)
-           and character not_eq '\r'
-           and character not_eq '\n')
-    {
-      value += character;
-      character = *++iterator;
-    }
-    //-----------------------------------
-    int lws_count {0};
-    //-----------------------------------
-    while (iterator not_eq sentinel
-           and (character == '\r' || character == '\n'))
-    {
-      character = *++iterator;
-      ++lws_count;
-    }
-    //-----------------------------------
-    if (lws_count == 3) break;
-    //-----------------------------------
-    while (iterator not_eq sentinel and isspace(character)) {
-      character = *++iterator;
+  while (size() < limit()) {
+    if ((break_point = fields_view.find(':')) not_eq std::experimental::string_view::npos) {
+      field = fields_view.substr(base, break_point);
       //-----------------------------------
-      if (iterator not_eq sentinel
-          and ((iterator + 1) not_eq sentinel)
-          and isspace(*(iterator + 1)))
-        continue;
-      //-----------------------------------
-      goto parse_value;
+      fields_view.remove_prefix(field.length() + 1U);
+      fields_view.remove_prefix(fields_view.find_first_not_of(' '));
     }
-    //-----------------------------------
-    add_field(field, value);
-    //-----------------------------------
-    ++limit;
-    //-----------------------------------
+    else {
+      break;
+    }
+
+    if ((break_point = fields_view.find("\r\n")) not_eq std::experimental::string_view::npos) {
+      value = fields_view.substr(base, break_point);
+      fields_.emplace_back(field, value);
+      fields_view.remove_prefix(value.length() + 2U);
+    }
+    else if ((break_point = fields_view.find('\n')) not_eq std::experimental::string_view::npos) {
+      value = fields_view.substr(base, break_point);
+      fields_.emplace_back(field, value);
+      fields_view.remove_prefix(value.length() + 1U);
+    }
+
+    if (fields_view[0] == '\r' or fields_view[0] == '\n') {
+      break;
+    }
   }
 }
 
-template <typename Field, typename Value, typename>
-inline bool Header::set_field(Field&& field, Value&& value) {
+template<typename>
+inline bool Header::set_field(const std::experimental::string_view field, const std::experimental::string_view value) {
   if (field.empty() || value.empty()) return false;
   //-----------------------------------
-  auto target = find(field);
+  const auto target = find(field);
   //-----------------------------------
-  if (target not_eq fields_.end()) {
-    const_cast<std::string&>((*target).second) = std::forward<Value>(value);
+  if (target not_eq fields_.cend()) {
+    const_cast<std::experimental::string_view&>(target->second) = value;
     return true;
   }
-  else return add_field(std::forward<Field>(field), std::forward<Value>(value));
+  else return add_field(field, value);
 }
 
-template <typename Field, typename>
-inline const std::string& Header::get_value(Field&& field) const noexcept {
+template<typename>
+inline std::experimental::string_view Header::value(const std::experimental::string_view field) const noexcept {
   if (field.empty()) return field;
-  //-----------------------------------
-  return find(std::forward<Field>(field))->second;
+  const auto it = find(field);
+  return (it not_eq fields_.cend()) ? it->second : std::experimental::string_view{};
 }
 
-template <typename Field, typename>
-inline bool Header::has_field(Field&& field) const noexcept {
+template<typename>
+inline bool Header::has_field(const std::experimental::string_view field) const noexcept {
   if (field.empty()) return false;
   //-----------------------------------
-  return find(std::forward<Field>(field)) not_eq fields_.end();
+  return find(field) not_eq fields_.cend();
 }
 
+template<typename>
 inline bool Header::is_empty() const noexcept {
   return fields_.empty();
 }
 
+template<typename>
 inline Limit Header::size() const noexcept {
   return fields_.size();
 }
 
-template <typename Field, typename>
-inline void Header::erase(Field&& field) noexcept {
+template<typename>
+inline void Header::erase(const std::experimental::string_view field) noexcept {
   if (field.empty()) return;
   //-----------------------------------
-  auto target = find(std::forward<Field>(field));
-  //-----------------------------------
-  if (target not_eq fields_.end()) fields_.erase(target);
+  Header_set::const_iterator target;
+  while ((target = find(field)) not_eq fields_.cend()) {
+    fields_.erase(target);
+  }
 }
 
+template<typename>
 inline void Header::clear() noexcept {
   fields_.clear();
 }
 
-inline static std::string string_to_lower_case(std::string s) {
-  std::transform(s.begin(), s.end(), s.begin(), ::tolower);
-  return s;
-}
-
-template <typename Field, typename>
-inline Header::Const_iterator Header::find(Field&& field) const noexcept {
-  if (field.empty()) return fields_.end();
-  //-----------------------------------
-  return
-  std::find_if(fields_.begin(), fields_.end(), [&field](const auto& f) {
-    return string_to_lower_case(f.first) == string_to_lower_case(field);
-  });
-}
-
 inline std::string Header::to_string() const {
-  std::ostringstream header;
-  //-----------------------------------
-  for (const auto& field : fields_) {
-    header << field.first << ": " << field.second << "\r\n";
+  if (size()) {
+    std::ostringstream header;
+    //-----------------------------------
+    for (const auto& field : fields_) {
+      header << field.first << ": " << field.second << "\r\n";
+    }
+    header << "\r\n";
+    //-----------------------------------
+    return header.str();
   }
-  //-----------------------------------
-  header << "\r\n";
-  //-----------------------------------
-  return header.str();
+
+  return {};
 }
 
 inline Header::operator std::string () const {
   return to_string();
 }
 
+template<typename>
+inline void Header::set_limit(const Limit limit) noexcept {
+  fields_.reserve(limit);
+}
+
+template<typename>
+inline Header_set::const_iterator Header::find(const std::experimental::string_view field) const noexcept {
+  if (field.empty()) return fields_.cend();
+  //-----------------------------------
+  return
+    std::find_if(fields_.cbegin(), fields_.cend(), [&field](const auto __) {
+      return (__.first.length() == field.length())
+        and std::equal(__.first.data(), __.first.data() + __.first.length(), field.data(), [](const auto a, const auto b) {
+          return std::tolower(a) == std::tolower(b);
+        });
+    });
+}
+
+/**
+ * @brief Operator to stream the of this class into the
+ * specified output device
+ *
+ * The output format is as follows:
+ * field : value "\r\n"
+ * field : value "\r\n"
+ * ...
+ * "\r\n"
+ *
+ * @param output_device:
+ * The output device to stream the contents from an instance of this
+ * class into
+ *
+ * @param header:
+ * An instance of this class
+ *
+ * @return Reference to the specified output device
+ */
 inline std::ostream& operator << (std::ostream& output_device, const Header& header) {
   return output_device << header.to_string();
 }

--- a/inc/header_fields.hpp
+++ b/inc/header_fields.hpp
@@ -18,71 +18,58 @@
 #ifndef HTTP_HEADER_FIELDS_HPP
 #define HTTP_HEADER_FIELDS_HPP
 
-#include <string>
+#include <experimental/string_view>
 
 namespace http {
 namespace header_fields {
 //------------------------------------------------
-using Field = const std::string;
+using Field = const std::experimental::string_view;
 //------------------------------------------------
 //------------------------------------------------
-namespace Request {
-Field Accept              {"Accept"};
-Field Accept_Charset      {"Accept-Charset"};
-Field Accept_Encoding     {"Accept-Encoding"};
-Field Accept_Language     {"Accept-Language"};
-Field Authorization       {"Authorization"};
-Field Connection          {"Connection"};
-Field Cookie              {"Cookie"};
-Field Expect              {"Expect"};
-Field From                {"From"};
-Field Host                {"Host"};
-Field HTTP2_Settings      {"HTTP2-Settings"};
-Field If_Match            {"If-Match"};
-Field If_Modified_Since   {"If-Modified-Since"};
-Field If_None_Match       {"If-None-Match"};
-Field If_Range            {"If-Range"};
-Field If_Unmodified_Since {"If-Unmodified-Since"};
-Field Max_Forwards        {"Max-Forwards"};
-Field Proxy_Authorization {"Proxy-Authorization"};
-Field Range               {"Range"};
-Field Referer             {"Referer"};
-Field TE                  {"TE"};
-Field Upgrade             {"Upgrade"};
-Field User_Agent          {"User-Agent"};
-} //< namespace Request
-//------------------------------------------------
-//------------------------------------------------
-namespace Response {
-Field Accept_Ranges       {"Accept-Ranges"};
-Field Age                 {"Age"};
-Field Connection          {"Connection"};
-Field ETag                {"ETag"};
-Field Location            {"Location"};
-Field Proxy_Authenticate  {"Proxy-Authenticate"};
-Field Retry_After         {"Retry-After"};
-Field Server              {"Server"};
-Field Set_Cookie          {"Set-Cookie"};
-Field Upgrade             {"Upgrade"};
-Field Vary                {"Vary"};
-Field WWW_Authenticate    {"WWW-Authenticate"};
-} //< namespace Response
-//------------------------------------------------
-//------------------------------------------------
-namespace Entity {
-Field Allow               {"Allow"};
-Field Content_Encoding    {"Content-Encoding"};
-Field Content_Language    {"Content-Language"};
-Field Content_Length      {"Content-Length"};
-Field Content_Location    {"Content-Location"};
-Field Content_MD5         {"Content-MD5"};
-Field Content_Range       {"Content-Range"};
-Field Content_Type        {"Content-Type"};
-Field Expires             {"Expires"};
-Field Last_Modified       {"Last-Modified"};
-} //< namespace Entity
-//------------------------------------------------
-//------------------------------------------------
+Field accept              {"Accept"};
+Field accept_charset      {"Accept-Charset"};
+Field accept_encoding     {"Accept-Encoding"};
+Field accept_ranges       {"Accept-Ranges"};
+Field accept_language     {"Accept-Language"};
+Field allow               {"Allow"};
+Field age                 {"Age"};
+Field authorization       {"Authorization"};
+Field connection          {"Connection"};
+Field cookie              {"Cookie"};
+Field content_encoding    {"Content-Encoding"};
+Field content_language    {"Content-Language"};
+Field content_length      {"Content-Length"};
+Field content_location    {"Content-Location"};
+Field content_md5         {"Content-MD5"};
+Field content_range       {"Content-Range"};
+Field content_type        {"Content-Type"};
+Field date                {"Date"};
+Field etag                {"ETag"};
+Field expect              {"Expect"};
+Field expires             {"Expires"};
+Field from                {"From"};
+Field host                {"Host"};
+Field http2_settings      {"HTTP2-Settings"};
+Field if_match            {"If-Match"};
+Field if_modified_since   {"If-Modified-Since"};
+Field if_none_match       {"If-None-Match"};
+Field if_range            {"If-Range"};
+Field if_unmodified_since {"If-Unmodified-Since"};
+Field last_modified       {"Last-Modified"};
+Field location            {"Location"};
+Field max_forwards        {"Max-Forwards"};
+Field proxy_authorization {"Proxy-Authorization"};
+Field proxy_authenticate  {"Proxy-Authenticate"};
+Field range               {"Range"};
+Field referer             {"Referer"};
+Field retry_after         {"Retry-After"};
+Field server              {"Server"};
+Field set_cookie          {"Set-Cookie"};
+Field te                  {"TE"};
+Field upgrade             {"Upgrade"};
+Field user_agent          {"User-Agent"};
+Field vary                {"Vary"};
+Field www_authenticate    {"WWW-Authenticate"};
 } //< namespace header_fields
 } //< namespace http
 

--- a/inc/http
+++ b/inc/http
@@ -1,3 +1,4 @@
+// -*- C++ -*-
 // This file is a part of the IncludeOS unikernel - www.includeos.org
 //
 // Copyright 2015-2016 Oslo and Akershus University College of Applied Sciences
@@ -14,8 +15,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
-// -*-C++-*-
 
 #ifndef ___HTTP_API___
 #define ___HTTP_API___

--- a/inc/message.hpp
+++ b/inc/message.hpp
@@ -18,8 +18,6 @@
 #ifndef HTTP_MESSAGE_HPP
 #define HTTP_MESSAGE_HPP
 
-#include <sstream>
-
 #include "time.hpp"
 #include "header.hpp"
 
@@ -30,18 +28,12 @@ namespace http {
  * HTTP message
  */
 class Message {
-private:
-  //----------------------------------------
-  // Internal class type aliases
-  using HSize        = Limit;
-  using HValue       = const std::string&;
-  using Message_Body = std::string;
-  //----------------------------------------
 public:
   /**
    * @brief Default constructor
    */
-  explicit Message() = default;
+  template<typename = void>
+  explicit Message();
 
   /**
    * @brief Constructor to specify the limit of how many
@@ -49,8 +41,9 @@ public:
    *
    * @param limit:
    * Maximum number of fields that can be added to the
-   * message             
+   * message
    */
+  template<typename = void>
   explicit Message(const Limit limit) noexcept;
 
   /**
@@ -76,235 +69,47 @@ public:
   /**
    * @brief Default move assignment operator
    */
-  Message& operator = (Message&&) = default;
+  Message& operator = (Message&&) noexcept = default;
 
   /**
-   * @brief Set the maximum number of fields that
-   * can be added to the header section for an instance
-   * of this class
+   * @brief Get a modifiable reference to the object that
+   * represents the header section
    *
-   * @param limit:
-   * The maximum number of fields that can be added to
-   * the header section
-   *
-   * @return The object that invoked this method
+   * @return Modifiable reference to the header object
    */
-  Message& set_header_limit(const Limit limit) noexcept;
-
-  /**
-   * @brief Get the current field limit for this
-   * message
-   *
-   * @return The current field limit
-   */
-  Limit get_header_limit() const noexcept;
-
-  /**
-   * @brief Add a new field to the current set of
-   * headers
-   *
-   * @tparam F field:
-   * The name of the field
-   *
-   * @tparam V value:
-   * The field value
-   *
-   * @return The object that invoked this method
-   */
-  template
-  <
-    typename F, typename V,
-    typename = std::enable_if_t
-               <std::is_same
-               <std::string, std::remove_const_t
-               <std::remove_reference_t<F>>>::value and
-                std::is_same
-               <std::string, std::remove_const_t
-               <std::remove_reference_t<V>>>::value>
-  >
-  Message& add_header(F&& field, V&& value);
-
-  /**
-   * @brief Add a set of fields to the header section of
-   * the message from a {std::string} object in the
-   * following format:
-   *
-   * "name: value\r\n"
-   * "name: value\r\n"
-   * ...
-   *
-   * @tparam D data:
-   * The set of fields to add to the header section of this
-   * message                     
-   *
-   * @return The object that invoked this method
-   */
-  template
-  <
-    typename D,
-    typename = std::enable_if_t
-               <std::is_same
-               <std::string, std::remove_const_t
-               <std::remove_reference_t<D>>>::value>
-  >
-  Message& add_headers(D&& data);
-
-  /**
-   * @brief Change the value of the specified field
-   *
-   * If the field is absent from the message it
-   * will be added with the associated value if
-   * within capacity of maximum allowable limit
-   *
-   * @tparam F field:
-   * The name of the field
-
-   * @tparam V value:
-   * The field value
-   *
-   * @return The object that invoked this method
-   */
-  template
-  <
-    typename F, typename V,
-    typename = std::enable_if_t
-               <std::is_same
-               <std::string, std::remove_const_t
-               <std::remove_reference_t<F>>>::value and
-                std::is_same
-               <std::string, std::remove_const_t
-               <std::remove_reference_t<V>>>::value>
-  >
-  Message& set_header(F&& field, V&& value);
+  template<typename = void>
+  Header& header() noexcept;
 
   /**
    * @brief Get a read-only reference to the object that
-   * represents the header section in this message
+   * represents the header section
    *
-   * @return The header in this message
+   * @return Read-only reference to the header object
    */
-  const Header& get_header() const noexcept;
-
-  /**
-   * @brief Get the value associated with the
-   * specified field name
-   *
-   * Should call <has_header> before calling this
-   *
-   * @tparam F field:
-   * The field name to get associated value
-   *
-   * @return The value associated with the specified
-   * field name
-   */
-  template
-  <
-    typename F,
-    typename = std::enable_if_t
-               <std::is_same
-               <std::string, std::remove_const_t
-               <std::remove_reference_t<F>>>::value>
-  >
-  HValue header_value(F&& field) const noexcept;
-
-  /**
-   * @brief Check if the specified field is within
-   * this message
-   *
-   * @tparam F field:
-   * The field name to search for
-   *
-   * @return true is present, false otherwise
-   */
-  template
-  <
-    typename F,
-    typename = std::enable_if_t
-               <std::is_same
-               <std::string, std::remove_const_t
-               <std::remove_reference_t<F>>>::value>
-  >
-  bool has_header(F&& field) const noexcept;
-
-  /**
-   * @brief Remove the specified field from this
-   * message
-   *
-   * @tparam F field:
-   * The header field to remove from this message
-   *
-   * @return The object that invoked this method
-   */
-  template
-  <
-    typename F,
-    typename = std::enable_if_t
-               <std::is_same
-               <std::string, std::remove_const_t
-               <std::remove_reference_t<F>>>::value>
-  >
-  Message& erase_header(F&& field) noexcept;
-
-  /**
-   * @brief Remove all header fields from this
-   * message
-   *
-   * @return The object that invoked this method
-   */
-  Message& clear_headers() noexcept;
-
-  /**
-   * @brief Check if there are no fields in this
-   * message
-   *
-   * @return true if the message has no fields,
-   * false otherwise
-   */
-  bool is_header_empty() const noexcept;
-
-  /**
-   * @brief Get the number of fields in this
-   * message
-   *
-   * @return The number of fields in this message
-   */
-  HSize header_size() const noexcept;
+  template<typename = void>
+  const Header& header() const noexcept;
 
   /**
    * @brief Add an entity to the message
    *
-   * @tparam E message_body:
-   * The entity to be sent with the message
+   * @param view:
+   * A view of the entity to be sent with the message
    *
    * @return The object that invoked this method
    */
-  template
-  <
-    typename E,
-    typename = std::enable_if_t
-               <std::is_same
-               <std::string, std::remove_const_t
-               <std::remove_reference_t<E>>>::value>
-  >
-  Message& add_body(E&& message_body);
+  template<typename = void>
+  Message& add_body(const std::experimental::string_view view);
 
   /**
    * @brief Append data to the entity of the message
    *
-   * @tparam D data:
-   * The data to append to the entity of the message
+   * @param view:
+   * A view of the data to append to the entity of the message
    *
    * @return The object that invoked this method
    */
-  template
-  <
-    typename D,
-    typename = std::enable_if_t
-               <std::is_same
-               <std::string, std::remove_const_t
-               <std::remove_reference_t<D>>>::value>
-  >
-  Message& append_body(D&& data);
+  template<typename = void>
+  Message& append_body(const std::experimental::string_view view);
 
   /**
    * @brief Get a read-only reference to the entity in
@@ -313,13 +118,15 @@ public:
    * @return A read-only reference to the entity in
    * this the message
    */
-  const Message_Body& get_body() const noexcept;
+  template<typename = void>
+  std::experimental::string_view body() const noexcept;
 
   /**
    * @brief Remove the entity from the message
    *
    * @return The object that invoked this method
    */
+  template<typename = void>
   Message& clear_body() noexcept;
 
   /**
@@ -346,109 +153,72 @@ public:
 private:
   //------------------------------
   // Class data members
-  Header       header_fields_;
-  Message_Body message_body_;
+  Header header_fields_;
+  std::string content_length_;
+  std::experimental::string_view message_body_;
+
+  std::string extended_body_;
   //------------------------------
 }; //< class Message
 
 /**--v----------- Implementation Details -----------v--**/
 
+template<typename>
+inline Message::Message() {}
+
+template<typename>
 inline Message::Message(const Limit limit) noexcept:
-  header_fields_{limit},
-  message_body_{}
+  header_fields_{limit}
 {}
 
-inline Message& Message::set_header_limit(const Limit limit) noexcept {
-  header_fields_.set_limit(limit);
-  return *this;
-}
-
-inline Limit Message::get_header_limit() const noexcept {
-  return header_fields_.get_limit();
-}
-
-template <typename Field, typename Value, typename>
-inline Message& Message::add_header(Field&& field, Value&& value) {
-  header_fields_.add_field(std::forward<Field>(field), std::forward<Value>(value));
-  return *this;
-}
-
-template <typename Data, typename>
-inline Message& Message::add_headers(Data&& data) {
-  header_fields_.add_fields(std::forward<Data>(data));
-  return *this;
-}
-
-template <typename Field, typename Value, typename>
-inline Message& Message::set_header(Field&& field, Value&& value) {
-  header_fields_.set_field(std::forward<Field>(field), std::forward<Value>(value));
-  return *this;
-}
-
-inline const Header& Message::get_header() const noexcept {
+template<typename>
+inline Header& Message::header() noexcept {
   return header_fields_;
 }
 
-template <typename Field, typename>
-inline Message::HValue Message::header_value(Field&& field) const noexcept {
-  return header_fields_.get_value(std::forward<Field>(field));
+template<typename>
+inline const Header& Message::header() const noexcept {
+  return header_fields_;
 }
 
-template <typename Field, typename>
-inline bool Message::has_header(Field&& field) const noexcept {
-  return header_fields_.has_field(std::forward<Field>(field));
-}
-
-template <typename Field, typename>
-inline Message& Message::erase_header(Field&& field) noexcept {
-  header_fields_.erase(std::forward<Field>(field));
+template<typename>
+inline Message& Message::add_body(const std::experimental::string_view view) {
+  if (view.empty()) return *this;
+  message_body_   = view;
+  content_length_ = std::to_string(message_body_.length());
+  header_fields_.add_field(header_fields::content_length, content_length_);
   return *this;
 }
 
-inline Message& Message::clear_headers() noexcept {
-  header_fields_.clear();
+template<typename>
+inline Message& Message::append_body(const std::experimental::string_view view) {
+  if (view.empty()) return *this;
+  //-----------------------------------
+  extended_body_ = message_body_.to_string();
+  extended_body_.insert(extended_body_.cend(), view.data(), view.data() + view.length());
+  message_body_ = extended_body_;
+  content_length_ = std::to_string(message_body_.length());
+  //-----------------------------------
+  header_fields_.set_field(header_fields::content_length, content_length_);
   return *this;
 }
 
-inline bool Message::is_header_empty() const noexcept {
-  return header_fields_.is_empty();
-}
-
-inline Message::HSize Message::header_size() const noexcept {
-  return header_fields_.size();
-}
-
-template<typename Entity, typename>
-inline Message& Message::add_body(Entity&& message_body) {
-  if (message_body.empty()) return *this;
-  //-----------------------------------
-  message_body_ = std::forward<Entity>(message_body);
-  //-----------------------------------
-  return add_header(header_fields::Entity::Content_Length,
-                    std::to_string(message_body_.size()));
-}
-
-template<typename Data, typename>
-inline Message& Message::append_body(Data&& data) {
-  if (data.empty()) return *this;
-  //-----------------------------------
-  message_body_.insert(message_body_.cend(), data.cbegin(), data.cend());
-  //-----------------------------------
-  return set_header(header_fields::Entity::Content_Length,
-                    std::to_string(message_body_.size()));
-}
-
-inline const Message::Message_Body& Message::get_body() const noexcept {
+template<typename>
+inline std::experimental::string_view Message::body() const noexcept {
   return message_body_;
 }
 
+template<typename>
 inline Message& Message::clear_body() noexcept {
-  message_body_.clear();
-  return erase_header(header_fields::Entity::Content_Length);
+  message_body_ = {};
+  extended_body_.clear();
+  header_fields_.erase(header_fields::content_length);
+  return *this;
 }
 
 inline Message& Message::reset() noexcept {
-  return clear_headers().clear_body();
+  header_fields_.clear();
+  return clear_body();
 }
 
 inline std::string Message::to_string() const {

--- a/inc/methods.hpp
+++ b/inc/methods.hpp
@@ -19,7 +19,7 @@
 #define HTTP_METHODS_HPP
 
 #include <array>
-#include <string>
+#include <experimental/string_view>
 #include <ostream>
 #include <unordered_map>
 
@@ -45,9 +45,10 @@ namespace http {
      *
      * @return The string representation of the code
      */
-    static const std::string& str(const Method m) {
+    template<typename = void>
+    std::experimental::string_view str(const Method m) noexcept {
 
-      const static std::array<std::string, 10> strings
+      const static std::array<std::experimental::string_view, 10> views
       {
         {
          "GET", "POST", "PUT", "DELETE", "OPTIONS",
@@ -55,13 +56,13 @@ namespace http {
         }
       };
 
-      auto e = strings.size() - 1;
+      const auto e = (views.size() - 1);
 
       if ((m >= 0) and (m < e)) {
-        return strings[m];
+        return views[m];
       }
 
-      return strings[e];
+      return views[e];
     }
 
     /**
@@ -73,9 +74,10 @@ namespace http {
      *
      * @return The code mapped to the method string
      **/
-    inline Method code(const std::string& method) noexcept {
+    template<typename = void>
+    Method code(const std::experimental::string_view method) noexcept {
 
-      const static std::unordered_map<std::string, Method> code_map {
+      const static std::unordered_map<std::experimental::string_view, Method> code_map {
         {"GET",     GET},
         {"POST",    POST},
         {"PUT",     PUT},
@@ -87,17 +89,19 @@ namespace http {
         {"PATCH",   PATCH}
       };
 
-      auto it = code_map.find(method);
+      const auto it = code_map.find(method);
 
-      return (it not_eq code_map.end()) ? it->second : INVALID;
+      return (it not_eq code_map.cend()) ? it->second : INVALID;
     }
 
+    template<typename = void>
     inline bool is_content_length_allowed(const Method method) noexcept {
-      return (method == POST) || (method == PUT);
+      return (method == POST) or (method == PUT);
     }
 
+    template<typename = void>
     inline bool is_content_length_required(const Method method) noexcept {
-      return (method == POST) || (method == PUT);
+      return (method == POST) or (method == PUT);
     }
 
   } //< namespace method

--- a/inc/mime_types.hpp
+++ b/inc/mime_types.hpp
@@ -18,13 +18,13 @@
 #ifndef HTTP_MIME_TYPES_HPP
 #define HTTP_MIME_TYPES_HPP
 
-#include <string>
+#include <experimental/string_view>
 #include <unordered_map>
 
 namespace http {
 //------------------------------------------------
-using Extension       = std::string;
-using Mime_type       = std::string;
+using Extension       = std::experimental::string_view;
+using Mime_type       = std::experimental::string_view;
 using Mime_type_table = std::unordered_map<Extension, Mime_type>;
 //------------------------------------------------
 const Mime_type_table mime_types {
@@ -96,12 +96,12 @@ const Mime_type_table mime_types {
   {"msm" , "application/octet-stream"}
 }; //< mime_types
 
-inline const Mime_type& extension_to_type(const Extension& extension) noexcept {
-  auto it = mime_types.find(extension);
+inline std::experimental::string_view ext_to_mime_type(const std::experimental::string_view extension) noexcept {
+  const auto it = mime_types.find(extension);
   //------------------------------------------------
-  return (it not_eq mime_types.end())
+  return (it not_eq mime_types.cend())
           ? it->second
-          : const_cast<Mime_type_table&>(mime_types)["bin"];
+          : "application/octet-stream";
 }
 
 } //< namespace http

--- a/inc/request.hpp
+++ b/inc/request.hpp
@@ -31,34 +31,25 @@ class Request : public Message {
 public:
   /**
    * @brief Default constructor
-   *
-   * Constructs a request message as follows:
-   *
-   * <GET / HTTP/1.1>
    */
-  explicit Request() = default;
+  template<typename = void>
+  explicit Request();
 
   /**
    * @brief Construct a request message from the
-   * incoming character stream of data which is
-   * a {std::string} object
+   * incoming character stream of data
    *
-   * @tparam T request:
+   * @param request:
    * The character stream of data
+   *
+   * @param len:
+   * The length of the character stream
    *
    * @param limit:
    * Capacity of how many fields can be added to
    * the header section
    */
-  template
-  <
-    typename T,
-    typename = std::enable_if_t
-               <std::is_same
-               <std::string, std::remove_const_t
-               <std::remove_reference_t<T>>>::value>
-  >
-  explicit Request(T&& request, const Limit limit = 25);
+  explicit Request(std::string request, const Limit limit = 25);
 
   /**
    * @brief Default copy constructor
@@ -90,6 +81,7 @@ public:
    *
    * @return The method of the request
    */
+  template<typename = void>
   Method method() const noexcept;
 
   /**
@@ -100,7 +92,8 @@ public:
    *
    * @return The object that invoked this method
    */
-  Request& set_method(const Method method);
+  template<typename = void>
+  Request& set_method(const Method method) noexcept;
 
   /**
    * @brief Get read-only reference to the URI of
@@ -109,6 +102,7 @@ public:
    * @return Read-only reference to the URI of
    * the request message
    */
+  template<typename = void>
   const URI& uri() const noexcept;
 
   /**
@@ -119,6 +113,7 @@ public:
    *
    * @return The object that invoked this method
    */
+  template<typename = void>
   Request& set_uri(const URI& uri);
 
   /**
@@ -126,6 +121,7 @@ public:
    *
    * @return The version of the request
    */
+  template<typename = void>
   Version version() const noexcept;
 
   /**
@@ -136,47 +132,34 @@ public:
    *
    * @return The object that invoked this method
    */
+  template<typename = void>
   Request& set_version(const Version version) noexcept;
 
   /**
    * @brief Get the value associated with the name
-   * field from a query string
+   * from a query string
    *
-   * @tparam T name:
+   * @param name:
    * The name to find the associated value
    *
    * @return The associated value if name was found,
    * an empty string otherwise
    */
-  template
-  <
-    typename T,
-    typename = std::enable_if_t
-               <std::is_same
-               <std::string, std::remove_const_t
-               <std::remove_reference_t<T>>>::value>
-  >
-  const std::string& query_value(T&& name) noexcept;
+  template<typename = void>
+  std::experimental::string_view query_value(const std::experimental::string_view name) noexcept;
 
   /**
    * @brief Get the value associated with the name
-   * field from the message body in a post request
+   * from the message body in a post request
    *
-   * @tparam T name:
+   * @param name:
    * The name to find the associated value
    *
    * @return The associated value if name was found,
    * an empty string otherwise
    */
-  template
-  <
-    typename T,
-    typename = std::enable_if_t
-               <std::is_same
-               <std::string, std::remove_const_t
-               <std::remove_reference_t<T>>>::value>
-  >
-  std::string post_value(T&& name) const noexcept;
+  template<typename = void>
+  std::experimental::string_view post_value(const std::experimental::string_view name) const noexcept;
 
   /**
    * @brief Reset the request message as if it was now
@@ -202,75 +185,86 @@ public:
 private:
   //----------------------------------------
   // Class data members
+  std::string request_;
   Request_line request_line_;
   //----------------------------------------
 }; //< class Request
 
 /**--v----------- Implementation Details -----------v--**/
 
-template <typename Ingress, typename>
-inline Request::Request(Ingress&& request, const Limit limit)
+template<typename>
+inline Request::Request() {}
+
+inline Request::Request(std::string request, const Limit limit)
   : Message{limit}
-  , request_line_{request}
+  , request_{std::move(request)}
 {
-  add_headers(request);
-  std::size_t start_of_body;
-  if ((start_of_body = request.find("\r\n\r\n")) not_eq std::string::npos) {
-    add_body(request.substr(start_of_body + 4));
-  } else if ((start_of_body = request.find("\n\n")) not_eq std::string::npos) {
-    add_body(request.substr(start_of_body + 2));
+  std::experimental::string_view request_view {request_};
+  request_line_ = Request_line{request_view};
+  header().add_fields(request_view);
+  std::experimental::string_view::size_type start_of_body;
+  if ((start_of_body = request_view.find("\r\n\r\n")) not_eq std::experimental::string_view::npos) {
+    add_body(request_view.substr(start_of_body + 4U));
+  } else if ((start_of_body = request_view.find("\n\n")) not_eq std::experimental::string_view::npos) {
+    add_body(request_view.substr(start_of_body + 2U));
   }
 }
 
+template<typename>
 inline Method Request::method() const noexcept {
-  return request_line_.get_method();
+  return request_line_.method();
 }
 
-inline Request& Request::set_method(const Method method) {
+template<typename>
+inline Request& Request::set_method(const Method method) noexcept {
   request_line_.set_method(method);
   return *this;
 }
 
+template<typename>
 inline const URI& Request::uri() const noexcept {
-  return request_line_.get_uri();
+  return request_line_.uri();
 }
 
+template<typename>
 inline Request& Request::set_uri(const URI& uri) {
   request_line_.set_uri(uri);
   return *this;
 }
 
+template<typename>
 inline Version Request::version() const noexcept {
-  return request_line_.get_version();
+  return request_line_.version();
 }
 
+template<typename>
 inline Request& Request::set_version(const Version version) noexcept {
   request_line_.set_version(version);
   return *this;
 }
 
-template <typename Name, typename>
-inline const std::string& Request::query_value(Name&& name) noexcept {
-  return request_line_.get_uri().query(std::forward<Name>(name));
+template<typename>
+inline std::experimental::string_view Request::query_value(const std::experimental::string_view name) noexcept {
+  return request_line_.uri().query(name.to_string());
 }
 
-template <typename Name, typename>
-inline std::string Request::post_value(Name&& name) const noexcept {
-  if ((method() not_eq POST) || get_body().empty() || name.empty()) {
-    return std::string{};
+template<typename>
+inline std::experimental::string_view Request::post_value(const std::experimental::string_view name) const noexcept {
+  if ((method() not_eq POST) or name.empty() or body().empty()) {
+    return {};
   }
   //---------------------------------
-  auto target = get_body().find(std::forward<Name>(name));
+  const auto target = body().find(name);
   //---------------------------------
-  if (target == std::string::npos) return std::string{};
+  if (target == std::experimental::string_view::npos) return {};
   //---------------------------------
-  auto focal_point = get_body().substr(target);
+  auto focal_point = body().substr(target);
   //---------------------------------
   focal_point = focal_point.substr(0, focal_point.find_first_of('&'));
   //---------------------------------
-  auto lock_and_load = focal_point.find('=');
+  const auto lock_and_load = focal_point.find('=');
   //---------------------------------
-  if (lock_and_load == std::string::npos) return std::string{};
+  if (lock_and_load == std::experimental::string_view::npos) return {};
   //---------------------------------
   return focal_point.substr(lock_and_load + 1);
 }
@@ -295,8 +289,17 @@ inline Request::operator std::string () const {
   return to_string();
 }
 
-inline Request_ptr make_request(buffer_t buf, const size_t len) {
-  return std::make_unique<Request>(std::string{reinterpret_cast<char*>(buf.get()), len});
+/**
+ * @brief Get a std::unique_ptr to a Request object
+ *
+ * @param request
+ * A character stream of data representing an HTTP request message
+ *
+ * @return A std::unique_ptr to a Request object
+ */
+template<typename = void>
+inline Request_ptr make_request(std::string request) {
+  return std::make_unique<Request>(std::move(request));
 }
 
 inline std::ostream& operator << (std::ostream& output_device, const Request& req) {

--- a/inc/response.hpp
+++ b/inc/response.hpp
@@ -6,9 +6,9 @@
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -45,28 +45,23 @@ public:
    * @param version:
    * The version of the message
    */
+  template<typename = void>
   explicit Response(const Code code = OK, const Version version = Version{}) noexcept;
 
   /**
-   * @brief Construct a response message from the
-   * incoming character stream of data which is a
-   * {std::string} object
+   * @brief Construct a response message from the incoming character
+   * stream of data
    *
-   * @tparam T response:
+   * @param response:
    * The character stream of data
+   *
+   * @param len:
+   * The length of the character stream
    *
    * @param limit:
    * Capacity of how many fields can be added to the header section
    */
-  template
-  <
-    typename T,
-    typename = std::enable_if_t
-               <std::is_same
-               <std::string, std::remove_const_t
-               <std::remove_reference_t<T>>>::value>
-  >
-  explicit Response(T&& response, const Limit limit = 100);
+  explicit Response(std::string response, const Limit limit = 25);
 
   /**
    * @brief  Default copy constructor
@@ -98,6 +93,7 @@ public:
    *
    * @return The status code of this message
    */
+  template<typename = void>
   Code status_code() const noexcept;
 
   /**
@@ -108,6 +104,7 @@ public:
    *
    * @return The object that invoked this method
    */
+  template<typename = void>
   Response& set_status_code(const Code code) noexcept;
 
   /**
@@ -117,7 +114,7 @@ public:
    * @return The object that invoked this method
    */
   virtual Response& reset() noexcept override;
-  
+
   /**
    * @brief Get a string representation of this
    * class
@@ -135,34 +132,39 @@ public:
 private:
   //------------------------------
   // Class data members
+  std::string response_;
   Status_line status_line_;
   //------------------------------
 }; //< class Response
 
 /**--v----------- Implementation Details -----------v--**/
 
+template<typename>
 inline Response::Response(const Code code, const Version version) noexcept
   : status_line_{version, code}
 {}
 
-template <typename Egress, typename>
-inline Response::Response(Egress&& response, const Limit limit)
+inline Response::Response(std::string response, const Limit limit)
   : Message{limit}
-  , status_line_{response}
+  , response_{std::move(response)}
 {
-  add_headers(response);
-  std::size_t start_of_body;
-  if ((start_of_body = response.find("\r\n\r\n")) not_eq std::string::npos) {
-    add_body(response.substr(start_of_body + 4));
-  } else if ((start_of_body = response.find("\n\n")) not_eq std::string::npos) {
-    add_body(response.substr(start_of_body + 2));
+  std::experimental::string_view response_view {response_};
+  status_line_ = Status_line{response_view};
+  header().add_fields(response_view);
+  std::experimental::string_view::size_type start_of_body;
+  if ((start_of_body = response_view.find("\r\n\r\n")) not_eq std::experimental::string_view::npos) {
+    add_body(response_view.substr(start_of_body + 4U));
+  } else if ((start_of_body = response_view.find("\n\n")) not_eq std::experimental::string_view::npos) {
+    add_body(response_view.substr(start_of_body + 2U));
   }
 }
 
+template<typename>
 inline Response::Code Response::status_code() const noexcept {
-  return static_cast<status_t>(status_line_.get_code());
+  return static_cast<status_t>(status_line_.code());
 }
 
+template<typename>
 inline Response& Response::set_status_code(const Code code) noexcept {
   status_line_.set_code(code);
   return *this;
@@ -186,15 +188,38 @@ inline Response::operator std::string () const {
   return to_string();
 }
 
-inline Response& operator << (Response& res, const Header_set& headers) {
+/**
+ * @brief Convenience function to add a set of header fields to the
+ * specified Response object
+ *
+ * @param response
+ * The Response object to add the header fields to
+ *
+ * @param headers
+ * The set of headers to add to the header section of the Response
+ * object
+ *
+ * @return The specified Response object
+ */
+template<typename = void>
+inline Response& operator << (Response& response, const Header_set& headers) {
   for (const auto& field : headers) {
-    res.add_header(field.first, field.second);
+    response.header().add_field(field.first, field.second);
   }
-  return res;
+  return response;
 }
 
-inline Response_ptr make_response(buffer_t buf, const size_t len) {
-  return std::make_unique<Response>(std::string{reinterpret_cast<char*>(buf.get()), len});
+/**
+ * @brief Get a std::unique_ptr to a Response object
+ *
+ * @param response
+ * A character stream of data representing an HTTP response message
+ *
+ * @return A std::unique_ptr to a Response object
+ */
+template<typename = void>
+inline Response_ptr make_response(std::string response) {
+  return std::make_unique<Response>(std::move(response));
 }
 
 inline std::ostream& operator << (std::ostream& output_device, const Response& res) {

--- a/inc/status_codes.hpp
+++ b/inc/status_codes.hpp
@@ -6,9 +6,9 @@
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -18,6 +18,7 @@
 #ifndef HTTP_STATUS_CODES_HPP
 #define HTTP_STATUS_CODES_HPP
 
+#include <experimental/string_view>
 #include <unordered_map>
 
 #include "status_code_constants.hpp"
@@ -25,7 +26,7 @@
 namespace http {
 //------------------------------------------------
 using Code              = int;
-using Description       = const char*;
+using Description       = std::experimental::string_view;
 using Status_code_table = std::unordered_map<Code, Description>;
 //------------------------------------------------
 const Status_code_table status_codes {
@@ -99,28 +100,33 @@ const Status_code_table status_codes {
 }; //< status_codes
 
 inline Description code_description(const Code code) noexcept {
-  auto iter = status_codes.find(code);
-  return (iter not_eq status_codes.end()) ? iter->second : "Internal Server Error";
+  const auto iter = status_codes.find(code);
+  return (iter not_eq status_codes.cend()) ? iter->second : "Internal Server Error";
 }
 
+template<typename = void>
 inline bool is_informational(const status_t status_code) noexcept {
-  return (status_code >= Continue) && (status_code <= Processing);
+  return (status_code >= Continue) and (status_code <= Processing);
 }
 
+template<typename = void>
 inline bool is_success(const status_t status_code) noexcept {
-  return (status_code >= OK) && (status_code <= IM_Used);
+  return (status_code >= OK) and (status_code <= IM_Used);
 }
 
+template<typename = void>
 inline bool is_redirection(const status_t status_code) noexcept {
-  return (status_code >= Multiple_Choices) && (status_code <= Permanent_Redirect);
+  return (status_code >= Multiple_Choices) and (status_code <= Permanent_Redirect);
 }
 
+template<typename = void>
 inline bool is_client_error(const status_t status_code) noexcept {
-  return (status_code >= Bad_Request) && (status_code <= Request_Header_Fields_Too_Large);
+  return (status_code >= Bad_Request) and (status_code <= Request_Header_Fields_Too_Large);
 }
 
+template<typename = void>
 inline bool is_server_error(const status_t status_code) noexcept {
-  return (status_code >= Internal_Server_Error) && (status_code <= Network_Authentication_Required);
+  return (status_code >= Internal_Server_Error) and (status_code <= Network_Authentication_Required);
 }
 
 } //< namespace http

--- a/inc/time.hpp
+++ b/inc/time.hpp
@@ -16,9 +16,10 @@
 // limitations under the License.
 
 #include <ctime>
-#include <string>
-#include <sstream>
+#include <experimental/string_view>
 #include <iomanip>
+#include <sstream>
+#include <string>
 
 namespace http {
 namespace time {
@@ -58,23 +59,23 @@ inline std::string from_time_t(const std::time_t time) {
  *
  * @note Returns a default initialized {time_t} object if an error occurred
  */
-inline std::time_t to_time_t(const std::string& time) {
+inline std::time_t to_time_t(const std::experimental::string_view time) {
   std::tm tm {};
 
   if (time.empty()) goto error;
 
   // Format: Sun, 06 Nov 1994 08:49:37 GMT
-  if (strptime(time.c_str(), "%a, %d %b %Y %H:%M:%S %Z", &tm) not_eq nullptr) {
+  if (strptime(time.data(), "%a, %d %b %Y %H:%M:%S %Z", &tm) not_eq nullptr) {
     return std::mktime(&tm);
   }
 
   // Format: Sunday, 06-Nov-94 08:49:37 GMT
-  if (strptime(time.c_str(), "%a, %d-%b-%y %H:%M:%S %Z", &tm) not_eq nullptr) {
+  if (strptime(time.data(), "%a, %d-%b-%y %H:%M:%S %Z", &tm) not_eq nullptr) {
     return std::mktime(&tm);
   }
 
   // Format: Sun Nov 6 08:49:37 1994
-  if(strptime(time.c_str(), "%a %b %d %H:%M:%S %Y", &tm) not_eq nullptr) {
+  if(strptime(time.data(), "%a %b %d %H:%M:%S %Y", &tm) not_eq nullptr) {
     return std::mktime(&tm);
   }
 
@@ -90,8 +91,7 @@ inline std::time_t to_time_t(const std::string& time) {
  * @note Returns an empty string if an error occurred
  */
 inline std::string now() {
-  auto time_object = std::time(nullptr);
-  return from_time_t(time_object);
+  return from_time_t(std::time(nullptr));
 }
 
 } //< namespace time

--- a/inc/version.hpp
+++ b/inc/version.hpp
@@ -6,9 +6,9 @@
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -18,7 +18,6 @@
 #ifndef HTTP_VERSION_HPP
 #define HTTP_VERSION_HPP
 
-#include <string>
 #include <sstream>
 
 namespace http {
@@ -38,7 +37,7 @@ public:
    * @param minor:
    * The minor version number
    */
-  explicit constexpr Version(const unsigned major = 1, const unsigned minor = 1) noexcept;
+  explicit constexpr Version(const unsigned major = 1U, const unsigned minor = 1U) noexcept;
 
   /**
    * @brief Default destructor
@@ -70,30 +69,38 @@ public:
    *
    * @return The major version number
    */
-  constexpr unsigned get_major() const noexcept;
+  template <typename = void>
+  constexpr unsigned major() const noexcept;
 
   /**
    * @brief Set the major version number
    *
    * @param major:
    * The major version number
+   *
+   * @return The object that invoked this method
    */
-  void set_major(const unsigned major) noexcept;
+  template <typename = void>
+  Version& set_major(const unsigned major) noexcept;
 
   /**
    * @brief Get the minor version number
    *
    * @return The minor version number
    */
-  constexpr unsigned get_minor() const noexcept;
+  template <typename = void>
+  constexpr unsigned minor() const noexcept;
 
   /**
    * @brief Set the minor version number
    *
    * @param minor:
    * The minor version number
+   *
+   * @return The object that invoked this method
    */
-  void set_minor(const unsigned minor) noexcept;
+  template <typename = void>
+  Version& set_minor(const unsigned minor) noexcept;
 
   /**
    * @brief Get a string representation of this
@@ -123,20 +130,26 @@ inline constexpr Version::Version(const unsigned major, const unsigned minor) no
   , minor_{minor}
 {}
 
-inline constexpr unsigned Version::get_major() const noexcept {
+template<typename>
+inline constexpr unsigned Version::major() const noexcept {
   return major_;
 }
 
-inline void Version::set_major(const unsigned major) noexcept {
+template<typename>
+inline Version& Version::set_major(const unsigned major) noexcept {
   major_ = major;
+  return *this;
 }
 
-inline constexpr unsigned Version::get_minor() const noexcept {
+template<typename>
+inline constexpr unsigned Version::minor() const noexcept {
   return minor_;
 }
 
-inline void Version::set_minor(const unsigned minor) noexcept {
+template<typename>
+inline Version& Version::set_minor(const unsigned minor) noexcept {
   minor_ = minor;
+  return *this;
 }
 
 inline std::string Version::to_string() const {
@@ -173,48 +186,54 @@ inline std::ostream& operator << (std::ostream& output_device, const Version& ve
 /**
  * @brief Operator to check for equality
  */
-inline bool operator == (const Version& lhs, const Version& rhs) noexcept {
-  return lhs.get_major() == rhs.get_major()
+template<typename = void>
+inline constexpr bool operator == (const Version lhs, const Version rhs) noexcept {
+  return lhs.major() == rhs.major()
          and
-         lhs.get_minor() == rhs.get_minor();
+         lhs.minor() == rhs.minor();
 }
 
 /**
  * @brief Operator to check for inequality
  */
-inline bool operator != (const Version& lhs, const Version& rhs) noexcept {
+template<typename = void>
+inline constexpr bool operator != (const Version lhs, const Version rhs) noexcept {
   return not (lhs == rhs);
 }
 
 /**
  * @brief Operator to check for less than relationship
  */
-inline bool operator < (const Version& lhs, const Version& rhs) noexcept {
-  return lhs.get_major() < rhs.get_major()
+template<typename = void>
+inline constexpr bool operator < (const Version lhs, const Version rhs) noexcept {
+  return lhs.major() < rhs.major()
          or
-         lhs.get_minor() < rhs.get_minor();
+         lhs.minor() < rhs.minor();
 }
 
 /**
  * @brief Operator to check for greater than relationship
  */
-inline bool operator > (const Version& lhs, const Version& rhs) noexcept {
-  return lhs.get_major() > rhs.get_major()
+template<typename = void>
+inline constexpr bool operator > (const Version lhs, const Version rhs) noexcept {
+  return lhs.major() > rhs.major()
          or
-         lhs.get_minor() > rhs.get_minor();
+         lhs.minor() > rhs.minor();
 }
 
 /**
  * @brief Operator to check for less than or equal to relationship
  */
-inline bool operator <= (const Version& lhs, const Version& rhs) noexcept {
+template<typename = void>
+inline constexpr bool operator <= (const Version lhs, const Version rhs) noexcept {
   return (lhs < rhs) or (lhs == rhs);
 }
 
 /**
  * @brief Operator to check for greater than or equal to relationship
  */
-inline bool operator >= (const Version& lhs, const Version& rhs) noexcept {
+template<typename = void>
+inline constexpr bool operator >= (const Version lhs, const Version rhs) noexcept {
   return (lhs > rhs) or (lhs == rhs);
 }
 

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -6,32 +6,56 @@
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-CPP=$(shell command -v clang++ || command -v clang++-3.8 || command -v clang++-3.7 || command -v clang++-3.6)
-CFLAGS=-std=c++14 -Ofast -Wall -Wextra
-INC=-I. -I../inc -I../uri/include -I../uri/GSL/include
+CXX=$(shell command -v clang++-3.9 || command -v clang++-3.8 || command -v clang++)
+CXXFLAGS=-std=c++14 -Ofast -Wall -Wextra
+INC=-I. -I../inc -I../uri/include -I../uri/GSL
 SRC=../uri/src/percent_encoding.cpp ../uri/src/uri.cpp
 
-all: request response
-	
+all: mime_types status_codes version methods header message status_line \
+		 request_line request response
+
+mime_types: mime_types_test.cpp test_machine.o
+	$(CXX) $(CXXFLAGS) $(INC) -omime_types mime_types_test.cpp test_machine.o
+
+status_codes: status_codes_test.cpp test_machine.o
+	$(CXX) $(CXXFLAGS) $(INC) -ostatus_codes status_codes_test.cpp test_machine.o
+
+version: version_test.cpp test_machine.o
+	$(CXX) $(CXXFLAGS) $(INC) -oversion version_test.cpp test_machine.o
+
+methods: methods_test.cpp test_machine.o
+	$(CXX) $(CXXFLAGS) $(INC) -omethods methods_test.cpp test_machine.o
+
+header: header_test.cpp test_machine.o
+	$(CXX) $(CXXFLAGS) $(INC) -oheader header_test.cpp test_machine.o
+
+message: message_test.cpp test_machine.o
+	$(CXX) $(CXXFLAGS) $(INC) -omessage message_test.cpp test_machine.o
+
+status_line: status_line_test.cpp test_machine.o
+	$(CXX) $(CXXFLAGS) $(INC) -ostatus_line status_line_test.cpp test_machine.o
+
+request_line: request_line_test.cpp test_machine.o
+	$(CXX) $(CXXFLAGS) $(INC) -orequest_line request_line_test.cpp test_machine.o $(SRC)
+
 request: request_test.cpp test_machine.o
-	$(CPP) $(CFLAGS) $(INC) -orequest request_test.cpp test_machine.o $(SRC)
+	$(CXX) $(CXXFLAGS) $(INC) -orequest request_test.cpp test_machine.o $(SRC)
 
 response: response_test.cpp test_machine.o
-	$(CPP) $(CFLAGS) $(INC) -oresponse response_test.cpp test_machine.o
+	$(CXX) $(CXXFLAGS) $(INC) -oresponse response_test.cpp test_machine.o
 
 test_machine.o: test_machine.cpp
-	$(CPP) $(CFLAGS) $(INC) -c test_machine.cpp
+	$(CXX) $(CXXFLAGS) $(INC) -c test_machine.cpp
 
 clean:
-	rm -f request
-	rm -f response
-	rm -f test_machine.o
+	rm -f mime_types status_codes version methods header message status_line \
+	      request_line request response

--- a/tests/header_test.cpp
+++ b/tests/header_test.cpp
@@ -1,0 +1,139 @@
+// This file is a part of the IncludeOS unikernel - www.includeos.org
+//
+// Copyright 2015-2016 Oslo and Akershus University College of Applied Sciences
+// and Alfred Bratterud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <catch.hpp>
+#include <header.hpp>
+
+///////////////////////////////////////////////////////////////////////////////
+TEST_CASE("Default constructor limits capacity to 25 fields", "[Header]") {
+  http::Header header;
+  REQUIRE(25U == header.limit());
+}
+
+///////////////////////////////////////////////////////////////////////////////
+TEST_CASE("Constructor to specify field limit", "[Header]") {
+  http::Header header {100U};
+  REQUIRE(100U == header.limit());
+}
+
+///////////////////////////////////////////////////////////////////////////////
+TEST_CASE("Default constructed object is empty", "[Header]") {
+  http::Header header;
+  REQUIRE(true == header.is_empty());
+}
+
+///////////////////////////////////////////////////////////////////////////////
+TEST_CASE("Add a field", "[Header]") {
+  http::Header header;
+  header.add_field(http::header_fields::server, "IncludeOS/Acorn v0.1");
+  REQUIRE(false == header.is_empty());
+  REQUIRE(1U == header.size());
+  REQUIRE(true == header.has_field(http::header_fields::server));
+}
+
+///////////////////////////////////////////////////////////////////////////////
+TEST_CASE("Get field value", "[Header]") {
+  http::Header header;
+  header.add_field(http::header_fields::server, "IncludeOS/Acorn v0.1");
+  REQUIRE(true == header.has_field(http::header_fields::server));
+  REQUIRE("IncludeOS/Acorn v0.1" == header.value(http::header_fields::server));
+}
+
+///////////////////////////////////////////////////////////////////////////////
+TEST_CASE("Set field value", "[Header]") {
+  http::Header header;
+  header.add_field(http::header_fields::server, "IncludeOS/Acorn v0.1");
+  REQUIRE("IncludeOS/Acorn v0.1" == header.value(http::header_fields::server));
+  header.set_field(http::header_fields::server, "IncludeOS/Acorn v2.0");
+  REQUIRE("IncludeOS/Acorn v2.0" == header.value(http::header_fields::server));
+}
+
+///////////////////////////////////////////////////////////////////////////////
+TEST_CASE("Erase field", "[Header]") {
+  http::Header header;
+  header.add_field(http::header_fields::server, "IncludeOS/Acorn v0.1");
+  header.erase(http::header_fields::server);
+  REQUIRE(false == header.has_field(http::header_fields::server));
+  REQUIRE(true == header.is_empty());
+}
+
+///////////////////////////////////////////////////////////////////////////////
+TEST_CASE("Cannot add fields beyond limit", "[Header]") {
+  http::Header header {3};
+  header.add_field(http::header_fields::server, "IncludeOS/Acorn v0.1");
+  header.add_field(http::header_fields::allow, "GET, HEAD");
+  header.add_field(http::header_fields::location, "/public/doc/unikernels.pdf");
+  header.add_field(http::header_fields::connection, "close");
+
+  const std::experimental::string_view test_string {
+    "Server: IncludeOS/Acorn v0.1\r\n"
+    "Allow: GET, HEAD\r\n"
+    "Location: /public/doc/unikernels.pdf\r\n\r\n"
+  };
+                                  ;
+  REQUIRE(3 == header.size());
+  REQUIRE(test_string == header.to_string());
+}
+
+///////////////////////////////////////////////////////////////////////////////
+TEST_CASE("Clear all fields", "[Header]") {
+  http::Header header;
+  header.add_field(http::header_fields::server, "IncludeOS/Acorn v0.1");
+  header.add_field(http::header_fields::connection, "close");
+  REQUIRE(2U == header.size());
+  header.clear();
+  REQUIRE(0U == header.size());
+  REQUIRE(true == header.is_empty());
+}
+
+///////////////////////////////////////////////////////////////////////////////
+TEST_CASE("Header to std::string conversion", "[Header]") {
+  http::Header header;
+  header.add_field(http::header_fields::server, "IncludeOS/Acorn v0.1");
+  header.add_field(http::header_fields::allow, "GET, HEAD");
+  header.add_field(http::header_fields::connection, "close");
+
+  const std::experimental::string_view test_string {
+    "Server: IncludeOS/Acorn v0.1\r\n"
+    "Allow: GET, HEAD\r\n"
+    "Connection: close\r\n\r\n"
+  };
+                                  ;
+  REQUIRE(test_string == header.to_string());
+}
+
+///////////////////////////////////////////////////////////////////////////////
+TEST_CASE("Add fields from a character stream", "[Header]") {
+  const std::experimental::string_view test_string {
+    "Server: IncludeOS/Acorn v0.1\r\n"
+    "Allow: GET, HEAD\r\n"
+    "Connection: close\r\n\r\n"
+  };
+
+  http::Header header {test_string};
+  REQUIRE(test_string == header.to_string());
+}
+
+///////////////////////////////////////////////////////////////////////////////
+TEST_CASE("Nonesense character stream gets rejected", "[Header]") {
+  const std::experimental::string_view test_string {
+    "[IncludeOS] A minimal, resource efficient unikernel for cloud services"
+  };
+
+  http::Header header {test_string};
+  REQUIRE(true == header.is_empty());
+}

--- a/tests/message_test.cpp
+++ b/tests/message_test.cpp
@@ -1,0 +1,69 @@
+// This file is a part of the IncludeOS unikernel - www.includeos.org
+//
+// Copyright 2015-2016 Oslo and Akershus University College of Applied Sciences
+// and Alfred Bratterud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <catch.hpp>
+#include <message.hpp>
+
+///////////////////////////////////////////////////////////////////////////////
+TEST_CASE("Default constructed message is blank", "[Message]") {
+  const http::Message message;
+  REQUIRE("" == message.to_string());
+}
+
+///////////////////////////////////////////////////////////////////////////////
+TEST_CASE("Get header section", "[Message]") {
+  http::Message message;
+  auto& header = message.header();
+  header.add_field(http::header_fields::server, "IncludeOS/Acorn v0.1");
+  header.add_field(http::header_fields::allow, "GET, HEAD");
+  header.add_field(http::header_fields::connection, "close");
+
+  const std::experimental::string_view test_string {
+    "Server: IncludeOS/Acorn v0.1\r\n"
+    "Allow: GET, HEAD\r\n"
+    "Connection: close\r\n\r\n"
+  };
+                                  ;
+  REQUIRE(test_string == message.to_string());
+}
+
+///////////////////////////////////////////////////////////////////////////////
+TEST_CASE("Add body", "[Message]") {
+  http::Message message;
+  message.add_body("[IncludeOS] A minimal, resource efficient unikernel for cloud services");
+
+  const std::experimental::string_view test_string {
+    "Content-Length: 70\r\n\r\n"
+    "[IncludeOS] A minimal, resource efficient unikernel for cloud services"
+  };
+
+  REQUIRE(test_string == message.to_string());
+}
+
+///////////////////////////////////////////////////////////////////////////////
+TEST_CASE("Append to body", "[Message]") {
+  http::Message message;
+  message.add_body("[IncludeOS] A minimal, resource efficient unikernel for cloud services")
+         .append_body(" http://www.includeos.org");
+
+  const std::experimental::string_view test_string {
+    "Content-Length: 95\r\n\r\n"
+    "[IncludeOS] A minimal, resource efficient unikernel for cloud services http://www.includeos.org"
+  };
+
+  REQUIRE(test_string == message.to_string());
+}

--- a/tests/methods_test.cpp
+++ b/tests/methods_test.cpp
@@ -1,0 +1,55 @@
+// This file is a part of the IncludeOS unikernel - www.includeos.org
+//
+// Copyright 2015-2016 Oslo and Akershus University College of Applied Sciences
+// and Alfred Bratterud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <catch.hpp>
+#include <methods.hpp>
+
+///////////////////////////////////////////////////////////////////////////////
+TEST_CASE("Valid HTTP code to string conversion", "[Methods]") {
+  const std::string test_string {"GET"};
+  REQUIRE(test_string == http::method::str(http::GET));
+}
+
+///////////////////////////////////////////////////////////////////////////////
+TEST_CASE("Invalid HTTP code to string conversion", "[Methods]") {
+  const std::string test_string {"INVALID"};
+  REQUIRE(test_string == http::method::str(static_cast<http::Method>(600)));
+}
+
+///////////////////////////////////////////////////////////////////////////////
+TEST_CASE("Valid HTTP method string to code conversion", "[Methods]") {
+  REQUIRE(http::GET == http::method::code("GET"));
+}
+
+///////////////////////////////////////////////////////////////////////////////
+TEST_CASE("Invalid HTTP method string to code conversion", "[Methods]") {
+  REQUIRE(http::INVALID == http::method::code("CALL"));
+}
+
+///////////////////////////////////////////////////////////////////////////////
+TEST_CASE("HTTP method require Content-Length header field", "[Methods]") {
+  REQUIRE(true == http::method::is_content_length_required(http::PUT));
+  REQUIRE(true == http::method::is_content_length_required(http::POST));
+  REQUIRE(false == http::method::is_content_length_required(http::HEAD));
+}
+
+///////////////////////////////////////////////////////////////////////////////
+TEST_CASE("HTTP method allowed Content-Length header field", "[Methods]") {
+  REQUIRE(true == http::method::is_content_length_allowed(http::PUT));
+  REQUIRE(true == http::method::is_content_length_allowed(http::POST));
+  REQUIRE(false == http::method::is_content_length_allowed(http::HEAD));
+}

--- a/tests/mime_types_test.cpp
+++ b/tests/mime_types_test.cpp
@@ -15,28 +15,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef HTTP_COMMON_HPP
-#define HTTP_COMMON_HPP
+#include <catch.hpp>
+#include <mime_types.hpp>
 
-#include <cstdint>
-#include <experimental/string_view>
-#include <memory>
-#include <uri>
-#include <utility>
-#include <vector>
+///////////////////////////////////////////////////////////////////////////////
+TEST_CASE("Extension that exist within the table", "[Mime_type_table]") {
+  REQUIRE(http::ext_to_mime_type("mpg") == "video/mpeg");
+}
 
-namespace http {
-
-  using URI        = uri::URI;
-  using Limit      = std::size_t;
-  using Header_set = std::vector<std::pair<std::experimental::string_view, std::experimental::string_view>>;
-
-  class Request;
-  using Request_ptr  = std::unique_ptr<Request>;
-
-  class Response;
-  using Response_ptr = std::unique_ptr<Response>;
-
-} //< namespace http
-
-#endif //< HTTP_COMMON_HPP
+///////////////////////////////////////////////////////////////////////////////
+TEST_CASE("Extension that doesn't exist within the table", "[Mime_type_table]") {
+  REQUIRE(http::ext_to_mime_type("zpr") == "application/octet-stream");
+}

--- a/tests/request_line_test.cpp
+++ b/tests/request_line_test.cpp
@@ -1,0 +1,106 @@
+// This file is a part of the IncludeOS unikernel - www.includeos.org
+//
+// Copyright 2015-2016 Oslo and Akershus University College of Applied Sciences
+// and Alfred Bratterud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <catch.hpp>
+#include <request_line.hpp>
+
+///////////////////////////////////////////////////////////////////////////////
+TEST_CASE("Default constructor", "[Request_line]") {
+  const http::Request_line request_line;
+  const std::experimental::string_view test_string {"GET / HTTP/1.1\r\n"};
+  REQUIRE(test_string == request_line.to_string());
+}
+
+///////////////////////////////////////////////////////////////////////////////
+TEST_CASE("Constructor taking a character stream", "[Request_line]") {
+  const std::experimental::string_view test_string {
+    "GET / HTTP/1.1\r\n"
+    "Host: 98.139.183.24\r\n"
+    "Accept: text/html\r\n"
+    "Connection: close\r\n\r\n"
+  };
+
+  const http::Request_line request_line {test_string};
+  const std::experimental::string_view result {"GET / HTTP/1.1\r\n"};
+  REQUIRE(result == request_line.to_string());
+}
+
+///////////////////////////////////////////////////////////////////////////////
+TEST_CASE("Nonesense character stream throws", "[Request_line]") {
+  const std::experimental::string_view test_string {
+    "[IncludeOS] A minimal, resource efficient unikernel for cloud services"
+  };
+
+  REQUIRE_THROWS_AS(http::Request_line{test_string}, http::Request_line_error);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+TEST_CASE("Empty character stream throws", "[Request_line]") {
+  REQUIRE_THROWS_AS(http::Request_line{""}, http::Request_line_error);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+TEST_CASE("Invalid status line throws [Missing HTTP version]", "[Request_line]") {
+  const std::experimental::string_view test_string {"GET / \n"};
+  REQUIRE_THROWS_AS(http::Request_line{test_string}, http::Request_line_error);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+TEST_CASE("Invalid line ending throws", "[Request_line]") {
+  const std::experimental::string_view test_string {"GET / HTTP/1.1\r"};
+  REQUIRE_THROWS_AS(http::Request_line{test_string}, http::Request_line_error);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+TEST_CASE("Get method", "[Request_line]") {
+  const http::Request_line request_line;
+  REQUIRE(http::GET == request_line.method());
+}
+
+///////////////////////////////////////////////////////////////////////////////
+TEST_CASE("Set method", "[Request_line]") {
+  http::Request_line request_line;
+  request_line.set_method(http::POST);
+  REQUIRE(http::POST == request_line.method());
+}
+
+///////////////////////////////////////////////////////////////////////////////
+TEST_CASE("Get version", "[Request_line]") {
+  const http::Request_line request_line;
+  REQUIRE((http::Version{1U, 1U} == request_line.version()));
+}
+
+///////////////////////////////////////////////////////////////////////////////
+TEST_CASE("Set version", "[Request_line]") {
+  http::Request_line request_line;
+  request_line.set_version(http::Version{2U, 0U});
+  REQUIRE((http::Version{2U, 0U} == request_line.version()));
+}
+
+///////////////////////////////////////////////////////////////////////////////
+TEST_CASE("Get uri", "[Request_line]") {
+  const http::Request_line request_line;
+  REQUIRE(uri::URI{"/"} == request_line.uri());
+}
+
+///////////////////////////////////////////////////////////////////////////////
+TEST_CASE("Set uri", "[Request_line]") {
+  http::Request_line request_line;
+  const uri::URI uri {"http://includeos.org"};
+  request_line.set_uri(uri);
+  REQUIRE(uri == request_line.uri());
+}

--- a/tests/request_test.cpp
+++ b/tests/request_test.cpp
@@ -6,9 +6,9 @@
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -21,90 +21,74 @@
 #define CRLF "\r\n"
 
 using namespace std;
-using namespace http;
 
 ///////////////////////////////////////////////////////////////////////////////
 TEST_CASE("Default constructor only creates request line", "[Request]") {
-  Request request;
-  //-------------------------
-  string test_string = "GET / HTTP/1.1" CRLF CRLF;
-  //-------------------------
+  const http:: Request request;
+  const std::string test_string {"GET / HTTP/1.1" CRLF};
   REQUIRE(test_string == request.to_string());
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 TEST_CASE("Constructor to parse a character stream", "[Request]") {
-  string ingress = "GET https://github.com/hioa-cs/IncludeOS HTTP/1.1" CRLF
-                   "Connection: close" CRLF CRLF;
-  //-------------------------                   
-  Request request {std::move(ingress)};
-  //-------------------------
-  REQUIRE(request.method()                    == GET);
-  REQUIRE(request.uri().to_string()           == "https://github.com/hioa-cs/IncludeOS");
-  REQUIRE(request.version()                   == Version(1, 1));
-  REQUIRE(request.has_header("Connection"s)   == true);
-  REQUIRE(request.header_value("Connection"s) == "close");
+ const std::string test_string {
+    "GET https://github.com/hioa-cs/IncludeOS HTTP/1.1" CRLF
+    "Connection: close" CRLF CRLF
+  };
+
+  http::Request request {std::move(test_string)};
+
+  REQUIRE(http::GET                              == request.method());
+  REQUIRE(true                                   == request.header().has_field(http::header_fields::connection));
+  REQUIRE("close"                                == request.header().value(http::header_fields::connection));
+  REQUIRE((http::Version{1, 1}                   == request.version()));
+  REQUIRE("https://github.com/hioa-cs/IncludeOS" == request.uri().to_string());
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 TEST_CASE("Building a request", "[Request]") {
-  Request request;
-  //-------------------------
-  request.add_header("Host"s, "includeos.server:8080"s)
-         .add_header("Accept"s, "text/html"s)
-         .add_header("Connection"s, "close"s);
-  //-------------------------
-  string test_string = "GET / HTTP/1.1" CRLF
-                       "Host: includeos.server:8080" CRLF
-                       "Accept: text/html" CRLF
-                       "Connection: close" CRLF CRLF;
-  //-------------------------
+  http::Request request;
+
+  request.header().add_field(http::header_fields::host, "includeos.server:8080");
+  request.header().add_field(http::header_fields::accept, "text/html");
+  request.header().add_field(http::header_fields::connection, "close");
+
+  const std::string test_string {
+    "GET / HTTP/1.1" CRLF
+    "Host: includeos.server:8080" CRLF
+    "Accept: text/html" CRLF
+    "Connection: close" CRLF CRLF
+  };
+
   REQUIRE(test_string == request.to_string());
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 TEST_CASE("Handling query data", "[Request]") {
-  string ingress = "GET includeos.net/q?file=install.sh&machine=x86_64 HTTP/1.1" CRLF
-                   "Host: includeos.server:8080" CRLF
-                   "Connection: close" CRLF CRLF;
-  //-------------------------
-  Request request {std::move(ingress)};
-  //-------------------------
-  REQUIRE(request.query_value("file"s)    == "install.sh");
-  REQUIRE(request.query_value("machine"s) == "x86_64");
+  const std::string test_string {
+    "GET includeos.net/q?file=install.sh&machine=x86_64 HTTP/1.1" CRLF
+    "Host: includeos.server:8080" CRLF
+    "Connection: close" CRLF CRLF
+  };
+
+  http::Request request {std::move(test_string)};
+
+  REQUIRE("x86_64"     == request.query_value("machine"));
+  REQUIRE("install.sh" == request.query_value("file"));
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 TEST_CASE("Handling post data", "[Request]") {
-  string ingress = "POST / HTTP/1.1" CRLF
-                   "Host: includeos.server:8080" CRLF
-                   "Connection: close" CRLF CRLF
-                   "name=rico&language=cpp&project=includeos";
-  //-------------------------
-  Request request {std::move(ingress)};
-  //-------------------------
-  REQUIRE(request.post_value("name"s)     == "rico");
-  REQUIRE(request.post_value("language"s) == "cpp");
-  REQUIRE(request.post_value("project"s)  == "includeos");
-}
+  const std::string test_string {
+    "POST / HTTP/1.1" CRLF
+    "Host: includeos.server:8080" CRLF
+    "Connection: close" CRLF CRLF
+    "name=rico&language=cpp&project=includeos"
+  };
 
-///////////////////////////////////////////////////////////////////////////////
-TEST_CASE("Header value folding", "[Request]") {
-  string ingress = "GET / HTTP/1.1" CRLF
-                   "Host: includeos.server:8080" CRLF
-                   "Client: curl/7.68" CRLF
-                   "Accept: text/plain;q=0.2," CRLF
-                   "        text/html;q=0.9," CRLF
-                   "        */*;q=0.1" CRLF
-                   "Connection: close" CRLF CRLF;
-  //-------------------------
-  Request request {std::move(ingress)};
-  //-------------------------
-  string test_string = "GET / HTTP/1.1" CRLF
-                       "Host: includeos.server:8080" CRLF
-                       "Client: curl/7.68" CRLF
-                       "Accept: text/plain;q=0.2, text/html;q=0.9, */*;q=0.1" CRLF
-                       "Connection: close" CRLF CRLF;
-  //-------------------------
-  REQUIRE(test_string == request.to_string());
+  http::Request request {std::move(test_string)};
+
+  REQUIRE("cpp"       == request.post_value("language"));
+  REQUIRE("rico"      == request.post_value("name"));
+  REQUIRE("includeos" == request.post_value("project"));
 }

--- a/tests/response_test.cpp
+++ b/tests/response_test.cpp
@@ -6,9 +6,9 @@
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -21,33 +21,30 @@
 #define CRLF "\r\n"
 
 using namespace std;
-using namespace http::header_fields;
 
 ///////////////////////////////////////////////////////////////////////////////
 TEST_CASE("Default constructor only creates status line", "[Response]") {
-  http::Response response;
-  //-------------------------
-  string test_string = "HTTP/1.1 200 OK" CRLF CRLF;
-  //-------------------------
+  const http::Response response;
+  const std::string test_string {"HTTP/1.1 200 OK" CRLF};
   REQUIRE(test_string == response.to_string());
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 TEST_CASE("Get status code", "[Response]") {
-  http::Response response;
-  //-------------------------
-  REQUIRE(response.status_code() == http::status_t::OK);
+  const http::Response response;
+  REQUIRE(http::OK == response.status_code());
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 SCENARIO("Given a Response object") {
    http::Response response;
-   //-------------------------
+
    WHEN("We set it's status code") {
-    response.set_status_code(http::status_t::Not_Found);
-    //-------------------------
+    response.set_status_code(http::Not_Found);
+
     THEN("It should be reflected") {
-      REQUIRE(response.to_string() == "HTTP/1.1 404 Not Found" CRLF CRLF);
+      const std::string test_string {"HTTP/1.1 404 Not Found" CRLF};
+      REQUIRE(test_string == response.to_string());
     }
    }
 }
@@ -55,84 +52,98 @@ SCENARIO("Given a Response object") {
 ///////////////////////////////////////////////////////////////////////////////
 TEST_CASE("Add header field", "[Response]") {
   http::Response response;
-  //-------------------------
-  response.add_header(Response::Server, "IncludeOS/0.7.0"s);
-  //-------------------------
-  string test_string = "HTTP/1.1 200 OK" CRLF
-                       "Server: IncludeOS/0.7.0" CRLF CRLF;
-  //-------------------------
+  response.header().add_field(http::header_fields::server, "IncludeOS/Acorn v0.7.0");
+
+  const std::string test_string {
+    "HTTP/1.1 200 OK" CRLF
+    "Server: IncludeOS/Acorn v0.7.0" CRLF CRLF
+  };
+
   REQUIRE(test_string == response.to_string());
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 TEST_CASE("{Date} header field", "[Response]") {
   http::Response response;
-  auto time_stamp = http::time::now();
-  //-------------------------
-  response.add_header(Response::Server, "IncludeOS/0.7.0"s)
-          .add_header("Date"s, time_stamp);
-  //-------------------------
-  string test_string = "HTTP/1.1 200 OK"s + "\r\n"s +
-                       "Server: IncludeOS/0.7.0"s + "\r\n"s +
-                       "Date: "s + time_stamp + "\r\n"s + "\r\n"s;
-  //-------------------------
+  const auto time_stamp = http::time::now();
+
+  response.header().add_field(http::header_fields::server, "IncludeOS/Acorn v0.7.0");
+  response.header().add_field(http::header_fields::date, time_stamp);
+
+  const std::string test_string {
+    "HTTP/1.1 200 OK"s + CRLF +
+    "Server: IncludeOS/Acorn v0.7.0" + CRLF +
+    "Date: " + time_stamp + CRLF + CRLF
+  };
+
   REQUIRE(test_string == response.to_string());
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 TEST_CASE("Change header field value", "[Response]") {
   http::Response response;
-  //-------------------------
-  response.add_header(Entity::Content_Type, "text/plain"s)
-          .set_header(Entity::Content_Type, "text/html"s);
-  //-------------------------
-  string test_string = "HTTP/1.1 200 OK" CRLF
-                       "Content-Type: text/html" CRLF CRLF;
-  //-------------------------
+
+  response.header().add_field(http::header_fields::content_type, "text/plain");
+  response.header().set_field(http::header_fields::content_type, "text/html");
+
+  const std::string test_string {
+    "HTTP/1.1 200 OK" CRLF
+    "Content-Type: text/html" CRLF CRLF
+  };
+
   REQUIRE(test_string == response.to_string());
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 TEST_CASE("Erase header field", "[Response]") {
-  http::Response response{http::status_t::Bad_Request};
-  //-------------------------
-  response.add_header(Response::Server, "IncludeOS/0.7.0"s)
-          .erase_header(Response::Server);
-  //-------------------------
-  string test_string = "HTTP/1.1 400 Bad Request" CRLF CRLF;
-  //-------------------------
+  http::Response response{http::Bad_Request};
+
+  response.header().add_field(http::header_fields::server, "IncludeOS/Acorn v0.7.0");
+  response.header().erase(http::header_fields::server);
+
+  const std::string test_string {"HTTP/1.1 400 Bad Request" CRLF};
+
   REQUIRE(test_string == response.to_string());
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 TEST_CASE("Clear headers", "[Response]") {
-  http::Response response{http::status_t::Bad_Request};
-  //-------------------------
-  response.add_header(Response::Server,     "IncludeOS/0.7.0"s)
-          .add_header(Entity::Content_Type, "text/javascript"s)
-          .clear_headers();
-  //-------------------------
-  string test_string = "HTTP/1.1 400 Bad Request" CRLF CRLF;
-  //-------------------------
+  http::Response response{http::Bad_Request};
+
+  response.header().add_field(http::header_fields::server, "IncludeOS/Acorn v0.7.0");
+  response.header().add_field(http::header_fields::content_type, "text/javascript");
+  response.header().clear();
+
+  const std::string test_string {"HTTP/1.1 400 Bad Request" CRLF};
+
   REQUIRE(test_string == response.to_string());
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 TEST_CASE("Add message body", "[Response]") {
   http::Response response;
-  //-------------------------
-  response.add_header(Response::Server,     "IncludeOS/0.7.0"s)
-          .add_header(Entity::Content_Type, "text/javascript"s);
-  //-------------------------
-  string javascript_file = "document.write('Hello from IncludeOS');";
-  //-------------------------
+
+  response.header().add_field(http::header_fields::server, "IncludeOS/Acorn v0.7.0");
+  response.header().add_field(http::header_fields::content_type, "text/javascript");
+
+  const std::string javascript_file {"document.write('Hello from IncludeOS');"};
+
   response.add_body(javascript_file);
-  //-------------------------
-  string test_string = "HTTP/1.1 200 OK" CRLF
-                       "Server: IncludeOS/0.7.0" CRLF
-                       "Content-Type: text/javascript" CRLF
-                       "Content-Length: 39" CRLF CRLF
-                       "document.write('Hello from IncludeOS');";
-  //-------------------------
+
+  const std::string test_string {
+    "HTTP/1.1 200 OK" CRLF
+    "Server: IncludeOS/Acorn v0.7.0" CRLF
+    "Content-Type: text/javascript" CRLF
+    "Content-Length: 39" CRLF CRLF
+    "document.write('Hello from IncludeOS');"
+  };
+
   REQUIRE(test_string == response.to_string());
+}
+
+///////////////////////////////////////////////////////////////////////////////
+TEST_CASE("Make Response_ptr", "[Response]") {
+  const auto response = http::make_response("HTTP/1.1 200 OK\r\n");
+  const std::string test_string {"HTTP/1.1 200 OK\r\n"};
+  REQUIRE(test_string == response->to_string());
 }

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -6,9 +6,9 @@
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -21,6 +21,22 @@ echo "About to run the test suite...";
 echo "Building...";
 make;
 echo "";
+echo "Testing mime_types module...";
+./mime_types;
+echo "Testing status_codes module...";
+./status_codes;
+echo "Testing version module...";
+./version;
+echo "Testing methods module...";
+./methods;
+echo "Testing header module...";
+./header;
+echo "Testing message module...";
+./message;
+echo "Testing status_line module...";
+./status_line;
+echo "Testing request_line module...";
+./request_line;
 echo "Testing request module...";
 ./request;
 echo "Testing response module...";

--- a/tests/status_codes_test.cpp
+++ b/tests/status_codes_test.cpp
@@ -1,0 +1,61 @@
+// This file is a part of the IncludeOS unikernel - www.includeos.org
+//
+// Copyright 2015-2016 Oslo and Akershus University College of Applied Sciences
+// and Alfred Bratterud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <catch.hpp>
+#include <status_codes.hpp>
+
+///////////////////////////////////////////////////////////////////////////////
+TEST_CASE("Valid code", "[Status Codes]") {
+  const std::string test_string {"Network Authentication Required"};
+  REQUIRE(test_string == http::code_description(http::Network_Authentication_Required));
+}
+
+///////////////////////////////////////////////////////////////////////////////
+TEST_CASE("Invalid code", "[Status Codes]") {
+  const std::string test_string {"Internal Server Error"};
+  REQUIRE(test_string == http::code_description(static_cast<http::status_t>(-200)));
+}
+
+///////////////////////////////////////////////////////////////////////////////
+TEST_CASE("Information codes", "[Status Codes]") {
+  REQUIRE(true == http::is_informational(http::Continue));
+  REQUIRE(false == http::is_informational(http::OK));
+}
+
+///////////////////////////////////////////////////////////////////////////////
+TEST_CASE("Success codes", "[Status Codes]") {
+  REQUIRE(true == http::is_success(http::OK));
+  REQUIRE(false == http::is_success(http::Continue));
+}
+
+///////////////////////////////////////////////////////////////////////////////
+TEST_CASE("Redirection codes", "[Status Codes]") {
+  REQUIRE(true == http::is_redirection(http::Temporary_Redirect));
+  REQUIRE(false == http::is_redirection(http::Reset_Content));
+}
+
+///////////////////////////////////////////////////////////////////////////////
+TEST_CASE("Client codes", "[Status Codes]") {
+  REQUIRE(true == http::is_client_error(http::Not_Acceptable));
+  REQUIRE(false == http::is_client_error(http::Gateway_Timeout));
+}
+
+///////////////////////////////////////////////////////////////////////////////
+TEST_CASE("Server codes", "[Status Codes]") {
+  REQUIRE(true == http::is_server_error(http::Not_Implemented));
+  REQUIRE(false == http::is_server_error(http::Use_Proxy));
+}

--- a/tests/status_line_test.cpp
+++ b/tests/status_line_test.cpp
@@ -1,0 +1,102 @@
+// This file is a part of the IncludeOS unikernel - www.includeos.org
+//
+// Copyright 2015-2016 Oslo and Akershus University College of Applied Sciences
+// and Alfred Bratterud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <catch.hpp>
+#include <status_line.hpp>
+
+///////////////////////////////////////////////////////////////////////////////
+TEST_CASE("Default constructor", "[Status_line]") {
+  http::Status_line status_line;
+  const std::experimental::string_view test_string {"HTTP/1.1 200 OK\r\n"};
+  REQUIRE(test_string == status_line.to_string());
+}
+
+///////////////////////////////////////////////////////////////////////////////
+TEST_CASE("Constructor specifying version and code", "[Status_line]") {
+  http::Status_line status_line {http::Version{2U, 0U}, http::Moved_Permanently};
+  const std::experimental::string_view test_string {"HTTP/2.0 301 Moved Permanently\r\n"};
+  REQUIRE(test_string == status_line.to_string());
+}
+
+///////////////////////////////////////////////////////////////////////////////
+TEST_CASE("Constructor taking a character stream", "[Status_line]") {
+  const std::experimental::string_view test_string {
+    "HTTP/2.0 301 Moved Permanently\r\n"
+    "Server: IncludeOS/Acorn v0.1\r\n"
+    "Allow: GET, HEAD\r\n"
+    "Location: /public/doc/unikernels.pdf\r\n\r\n"
+  };
+
+  http::Status_line status_line {test_string};
+
+  const std::experimental::string_view result {"HTTP/2.0 301 Moved Permanently\r\n"};
+  REQUIRE(result == status_line.to_string());
+}
+
+///////////////////////////////////////////////////////////////////////////////
+TEST_CASE("Nonesense character stream throws", "[Status_line]") {
+  const std::experimental::string_view test_string {
+    "[IncludeOS] A minimal, resource efficient unikernel for cloud services"
+  };
+
+  REQUIRE_THROWS_AS(http::Status_line{test_string}, http::Status_line_error);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+TEST_CASE("Empty character stream throws", "[Status_line]") {
+  REQUIRE_THROWS_AS(http::Status_line{""}, http::Status_line_error);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+TEST_CASE("Invalid status line throws [Missing code description]", "[Status_line]") {
+  const std::experimental::string_view test_string {"HTTP/2.0 301\n"};
+  REQUIRE_THROWS_AS(http::Status_line{test_string}, http::Status_line_error);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+TEST_CASE("Invalid line ending throws", "[Status_line]") {
+  const std::experimental::string_view test_string {"HTTP/2.0 301 Moved Permanently\r"};
+  REQUIRE_THROWS_AS(http::Status_line{test_string}, http::Status_line_error);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+TEST_CASE("Set version", "[Status_line]") {
+  http::Status_line status_line {http::Version{}, http::OK};
+  status_line.set_version(http::Version{2U, 0U});
+  const std::experimental::string_view test_string {"HTTP/2.0 200 OK\r\n"};
+  REQUIRE(test_string == status_line.to_string());
+}
+
+///////////////////////////////////////////////////////////////////////////////
+TEST_CASE("Get version", "[Status_line]") {
+  http::Status_line status_line {http::Version{1U, 1U}, http::OK};
+  REQUIRE((http::Version{1U, 1U} == status_line.version()));
+}
+
+///////////////////////////////////////////////////////////////////////////////
+TEST_CASE("Set code", "[Status_line]") {
+  http::Status_line status_line {http::Version{}, http::OK};
+  status_line.set_code(http::Processing);
+  const std::experimental::string_view test_string {"HTTP/1.1 102 Processing\r\n"};
+  REQUIRE(test_string == status_line.to_string());
+}
+
+///////////////////////////////////////////////////////////////////////////////
+TEST_CASE("Get code", "[Status_line]") {
+  http::Status_line status_line {http::Version{1U, 1U}, http::Processing};
+  REQUIRE(http::Processing == status_line.code());
+}

--- a/tests/version_test.cpp
+++ b/tests/version_test.cpp
@@ -1,0 +1,75 @@
+// This file is a part of the IncludeOS unikernel - www.includeos.org
+//
+// Copyright 2015-2016 Oslo and Akershus University College of Applied Sciences
+// and Alfred Bratterud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <catch.hpp>
+#include <version.hpp>
+
+///////////////////////////////////////////////////////////////////////////////
+SCENARIO("Given a Version object") {
+   http::Version version;
+
+   WHEN("We set its major version number") {
+    version.set_major(2U);
+
+    THEN("It should be reflected") {
+      REQUIRE(version.major() == 2U);
+    }
+   }
+
+   WHEN("We set its minor version number") {
+    version.set_minor(0U);
+
+    THEN("It should be reflected") {
+      REQUIRE(version.minor() == 0U);
+    }
+   }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+TEST_CASE("Convert a Version object to a std::string", "[Version]") {
+  const http::Version version;
+  const std::string test_string {"HTTP/1.1"};
+  REQUIRE(test_string == version.to_string());
+}
+
+///////////////////////////////////////////////////////////////////////////////
+TEST_CASE("Equality", "[Version]") {
+  const http::Version a {2U, 0U};
+  const http::Version b {a};
+  REQUIRE(a == b);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+TEST_CASE("Inequality", "[Version]") {
+  const http::Version a;
+  const http::Version b {2U, 0U};
+  REQUIRE(a not_eq b);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+TEST_CASE("Greater than", "[Version]") {
+  const http::Version a;
+  const http::Version b {2U, 0U};
+  REQUIRE(b > a);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+TEST_CASE("Less than", "[Version]") {
+  const http::Version a;
+  const http::Version b {2U, 0U};
+  REQUIRE(a < b);
+}


### PR DESCRIPTION
# API Changes
* All standard header fields are now placed under `http::header_fields` with fields names in common case
* `http:extension_to_type` -> `http::ext_to_mime_type`
* `make_request(buffer_t, const size_t)` -> `make_request(std::string)`
* `Request_line::get_method` -> `Request_line::method`
* `Request_line::get_uri` -> `Request_line::uri`
* `Request_line::get_version` -> `Request_line::version`
* `Status_line::get_code` -> `Status_line::code`
* `Status_line::get_version` -> `Status_line::version`
* `Version::get_minor` -> `Version::minor`
* `Version::get_major` -> `Version::major`